### PR TITLE
Fix: Thumbsdown emoji should correspond to negative feedback 

### DIFF
--- a/packages/adapters/factory/package.json
+++ b/packages/adapters/factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samagra-x/uci-adapters-factory",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A factory module which provides specific adapter instance based on request data.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/adapters/gupshup-whatsapp/package.json
+++ b/packages/adapters/gupshup-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samagra-x/uci-adapters-gupshup-whatsapp-adapter",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/adapters/gupshup-whatsapp/src/GupShupWhatsappAdapter.ts
+++ b/packages/adapters/gupshup-whatsapp/src/GupShupWhatsappAdapter.ts
@@ -452,7 +452,7 @@ export class GupshupWhatsappProvider implements XMessageProvider {
         to,
         MessageState.REPLIED,
         messageIdentifier,
-        MessageType.FEEDBACK_POSITIVE,
+        MessageType.FEEDBACK_NEGATIVE,
       );
     }
     else if (message.type === 'text' && message.text) {


### PR DESCRIPTION
fixes #102 

- `FEEDBACK_POSITIVE` -> `FEEDBACK_NEGATIVE`
- Changed adapter version `1.1.1` -> `1.1.2`
- Changed factory version `1.1.1` -> `1.1.2`