### PR TITLE
Fix: <newline> not getting replaced with \n

### DIFF
--- a/packages/transformers/package.json
+++ b/packages/transformers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samagra-x/uci-transformers",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "description": "Library of services, actions and gaurds used to create any custom bot using Xstate configuration.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/transformers/src/modules/generic/llm/llm.transformer.ts
+++ b/packages/transformers/src/modules/generic/llm/llm.transformer.ts
@@ -310,7 +310,7 @@ export class LLMTransformer implements ITransformer {
                 }
             }
             await this.sendMessage(xmsg)
-            xmsg.payload.text = translatedSentences.join(' ')?.replace("<end/>",'')
+            xmsg.payload.text = xmsg.payload.text?.replace("<end/>",'')
         }
         delete process.env['OPENAI_API_KEY'];
         xmsg.messageId.Id = oldMessageId;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved processing of `translatedSentences` to ensure better text handling.
  - Updated text assignment to remove `<end/>` directly from `xmsg.payload.text`, resulting in cleaner output.

- **Chores**
  - Updated the package version from `1.3.15` to `1.3.16`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->