### PR TITLE
Stringify object values in field setter.

### DIFF
--- a/packages/transformers/package.json
+++ b/packages/transformers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samagra-x/uci-transformers",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "description": "Library of services, actions and gaurds used to create any custom bot using Xstate configuration.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/transformers/src/modules/generic/field_setter/field_setter.transformer.spec.ts
+++ b/packages/transformers/src/modules/generic/field_setter/field_setter.transformer.spec.ts
@@ -169,4 +169,24 @@ describe('Field Setter Tests', () => {
         xmsgCopy.channelURI = '';
         expect(xmsgCopy).toStrictEqual(transformedMsg);
     });
+
+    it('Field Setter stringifies objects', async () => {
+        const xmsgCopy = JSON.parse(JSON.stringify(mockXMessage));
+        xmsgCopy.transformer!.metaData!.myObjectData = {
+            "myVar1": "myValue1",
+            "myVar2": {
+                "myInnerVar": "myInnerValue",
+            }
+        }
+        xmsgCopy.transformer!.metaData!.myObjectData2 = ['a', 'b', 'c'];
+        const transformer = new FieldSetterTransformer({
+            setters: {
+                "payload.text": "{{msg:transformer.metaData.myObjectData}}",
+                "transformer.metaData.checkVal": "{{msg:transformer.metaData.myObjectData2}}"
+            }
+        });
+        const transformedMsg = await transformer.transform(xmsgCopy);
+        expect(transformedMsg.payload.text).toStrictEqual("{\"myVar1\":\"myValue1\",\"myVar2\":{\"myInnerVar\":\"myInnerValue\"}}");
+        expect(transformedMsg.transformer!.metaData!.checkVal).toStrictEqual("[\"a\",\"b\",\"c\"]");
+    });
 })

--- a/packages/transformers/src/modules/generic/field_setter/field_setter.transformer.ts
+++ b/packages/transformers/src/modules/generic/field_setter/field_setter.transformer.ts
@@ -62,7 +62,13 @@ export class FieldSetterTransformer implements ITransformer {
             replacements[matched[0]] = get(xmsg.transformer?.metaData?.userHistory[0] ?? {}, matched[1]);
         }
         Object.entries(replacements).forEach((replacement) => {
-            value = value.replaceAll(replacement[0], replacement[1] ?? '');
+            value = value.replaceAll(
+                replacement[0],
+                replacement[1] ?
+                typeof replacement[1] == 'object' ?
+                JSON.stringify(replacement[1]) : replacement[1]
+                : ''
+            );
         });
         return value;
     }


### PR DESCRIPTION
Fixes: #140 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced `FieldSetterTransformer` to handle object replacements by converting them to JSON strings, ensuring more robust data transformation.

- **Tests**
  - Added a new test case to verify that objects are correctly stringified before transformation in the `Field Setter Tests`.

- **Chores**
  - Updated the version of `@samagra-x/uci-transformers` from 1.3.16 to 1.3.17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->