### PR TITLE
feat: add support for json response format

### DIFF
--- a/packages/transformers/package.json
+++ b/packages/transformers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samagra-x/uci-transformers",
-  "version": "1.3.21",
+  "version": "1.3.22",
   "description": "Library of services, actions and gaurds used to create any custom bot using Xstate configuration.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/transformers/registry.json
+++ b/packages/transformers/registry.json
@@ -351,6 +351,13 @@
         "name": "languageProvider",
         "type": "string",
         "optional": true
+      },
+      {
+        "label": "Response Format",
+        "name": "responseFormat",
+        "type": "ide",
+        "optional": false,
+        "rows": 2
       }
     ],
     "outputs": [

--- a/packages/transformers/src/modules/generic/llm/config.json
+++ b/packages/transformers/src/modules/generic/llm/config.json
@@ -83,6 +83,13 @@
             "name": "languageProvider",
             "type": "string",
             "optional": true
+        },
+        {
+            "label": "Response Format",
+            "name": "responseFormat",
+            "type": "ide",
+            "optional": false,
+            "rows": 2
         }
     ],
     "outputs": [

--- a/packages/transformers/src/modules/generic/llm/llm.transformer.spec.ts
+++ b/packages/transformers/src/modules/generic/llm/llm.transformer.spec.ts
@@ -12,7 +12,7 @@ const openai200normal = {
     "choices": [
         {
             "message": {
-                content:"The capital of France is Paris.",
+                content: "The capital of France is Paris.",
             },
             "index": 0,
             "logprobs": null,
@@ -37,7 +37,7 @@ let mockOpenAIresponses = {
 jest.mock('openai', () => {
     return jest.fn().mockImplementation(() => {
         return {
-            chat:{
+            chat: {
                 completions: {
                     create: jest.fn().mockImplementation(async () => { return mockOpenAIresponses.create; })
                 }
@@ -148,15 +148,15 @@ describe("LLMTransformer Tests", () => {
                 }
             }
         };
-        
+
         const transformedXMessage = await transformer.transform(xmsgNonEnglish);
         expect(transformedXMessage.payload.text).toContain("France");
     });
 
     it('should throw error if model is not defined', async () => {
-        const transformer = new LLMTransformer({ 
+        const transformer = new LLMTransformer({
             APIKey: 'mockApiKey',
-            eventBus 
+            eventBus
         });
         const config = {
             APIKey: 'mockkey',
@@ -176,6 +176,44 @@ describe("LLMTransformer Tests", () => {
             APIKey: 'mockkey',
             model: 'gpt-3.5-turbo',
             outboundURL: 'mockOutboundURL',
+            eventBus
+        };
+        const transformer = new LLMTransformer(config);
+        expect(transformer.config).toEqual(config);
+        expect(transformer.sendMessage).toBeInstanceOf(Function);
+        expect(transformer.transform).toBeInstanceOf(Function);
+    })
+
+    it('should respect responseFormat in transformer config', () => {
+        const config = {
+            APIKey: 'mockkey',
+            model: 'gpt-3.5-turbo',
+            outboundURL: 'mockOutboundURL',
+            response_format: {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "reasoning_schema",
+                    "strict": true,
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "reasoning_steps": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "description": "The reasoning steps leading to the final conclusion."
+                            },
+                            "answer": {
+                                "type": "string",
+                                "description": "The final answer, taking into account the reasoning steps."
+                            }
+                        },
+                        "required": ["reasoning_steps", "answer"],
+                        "additionalProperties": false
+                    }
+                }
+            },
             eventBus
         };
         const transformer = new LLMTransformer(config);
@@ -216,7 +254,7 @@ describe("LLMTransformer Tests", () => {
         };
         await expect(transformer.transform(xmsgEmptyPayload)).rejects.toThrow(
             "`xmsg.payload.text` not defined in LLM transformer"
-          );
+        );
     });
 
 });

--- a/packages/transformers/src/modules/generic/llm/llm.transformer.ts
+++ b/packages/transformers/src/modules/generic/llm/llm.transformer.ts
@@ -28,6 +28,7 @@ export class LLMTransformer implements ITransformer {
     ///     temperature: The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. (default: `0`) (optional)
     ///     enableStream: boolean which allowes user to get streaming responses if enabled. By default this is set to `false`. (optional)
     ///     outputLanguage: Stream output language. Defaults to 'en'. (optional)
+    ///     responseFormat: Used to pass the json schema of the reponse format for OpenAI LLM calls. (optional)
     constructor(readonly config: Record<string, any>) { }
 
     // TODO: use TRANSLATE transformer directly instead of repeating code
@@ -162,12 +163,16 @@ export class LLMTransformer implements ITransformer {
         } else {
             // OPEN AI Implementaion
             const openai = new OpenAI({apiKey: this.config.APIKey});
-            response = await openai.chat.completions.create({
+            const openAIChatConfig: any = {
                 model: this.config.model,
                 messages: prompt,
                 temperature: this.config.temperature || 0,
                 stream: this.config.enableStream ?? false,
-            }).catch((ex) => {
+            };
+            if(this.config.responseFormat) {
+                openAIChatConfig.response_format = this.config.responseFormat;
+            }
+            response = await openai.chat.completions.create(openAIChatConfig).catch((ex) => {
                 console.error(`LLM failed. Reason: ${ex}`);
                 throw ex;
             });


### PR DESCRIPTION
Refer - https://openai.com/index/introducing-structured-outputs-in-the-api/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an optional `responseFormat` parameter for customizing the JSON schema of responses when calling OpenAI's LLM.
  - Added a new configuration option for `responseFormat` in the `registry.json` and `config.json` files, enhancing user interaction flexibility.

- **Documentation**
  - Enhanced documentation for the `LLMTransformer` class to clarify the new `responseFormat` configuration option.

- **Tests**
  - Added new test cases to validate the handling of the `response_format` configuration in the `LLMTransformer`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->