### PR TITLE
fix: broadcast transformer name in config

### DIFF
--- a/packages/transformers/registry.json
+++ b/packages/transformers/registry.json
@@ -1,6 +1,6 @@
 [
   {
-    "label": "Code Runner Transformer",
+    "label": "Broadcast Transformer",
     "type": "BROADCAST_TRANSFORMER",
     "class": "GenericTransformer",
     "description": "A node used to configure broadcast messages.",

--- a/packages/transformers/src/modules/generic/broadcast/config.json
+++ b/packages/transformers/src/modules/generic/broadcast/config.json
@@ -1,5 +1,5 @@
 {
-    "label": "Code Runner Transformer",
+    "label": "Broadcast Transformer",
     "type": "BROADCAST_TRANSFORMER",
     "class": "GenericTransformer",
     "description": "A node used to configure broadcast messages.",


### PR DESCRIPTION
- **fix: broadcast transformer name**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Updated transformer label from "Code Runner Transformer" to "Broadcast Transformer" for improved clarity on its functionality.

- **Style**
  - Adjusted formatting in the FieldToStateTransformer class for better code readability. 

These changes enhance user understanding of the transformer’s purpose while maintaining existing functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->