### PR TITLE
Preserve new messageId in streaming LLM.

### DIFF
--- a/packages/transformers/package.json
+++ b/packages/transformers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samagra-x/uci-transformers",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Library of services, actions and gaurds used to create any custom bot using Xstate configuration.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/transformers/src/modules/generic/llm/llm.transformer.spec.ts
+++ b/packages/transformers/src/modules/generic/llm/llm.transformer.spec.ts
@@ -304,5 +304,7 @@ describe("LLMTransformer Tests", () => {
         // Check `messageIdChanged` is only set for messages
         // directly sent by LLM.
         expect(transformedXMsg.payload.metaData?.messageIdChanged).toBeUndefined();
+        // Check if new message id used for streams has been preserved in metaData.
+        expect(transformedXMsg.transformer?.metaData?.streamMessageId).toBeDefined();
     });
 });

--- a/packages/transformers/src/modules/generic/llm/llm.transformer.ts
+++ b/packages/transformers/src/modules/generic/llm/llm.transformer.ts
@@ -309,6 +309,7 @@ export class LLMTransformer implements ITransformer {
                 ...xmsg.transformer,
                 metaData: {
                     ...xmsg.transformer?.metaData,
+                    streamMessageId: newMessageId,
                     responseInEnglish: allSentences.join(' ')?.replace("<end/>",'')?.replace(/<newline>/g, '\n')?.replace(/<ନୂତନ ଲାଇନ୍>/g, '\n')?.replace(/<न्यूलाइन>/g, '\n')?.replace(/<नई लाइन>/g, '\n'),
                     streamStartLatency
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `@samagra-x/uci-transformers` package to version 1.4.2, introducing potential new features and improvements.
	- Added a `streamMessageId` property to enhance message tracking in the `LLMTransformer` class.

- **Tests**
	- Improved test coverage for the `LLMTransformer` by adding an assertion to ensure the preservation of `streamMessageId` during message transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->