### PR TITLE
Update FCM provider and broadcast transformer

### DIFF
--- a/packages/adapters/factory/package.json
+++ b/packages/adapters/factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samagra-x/uci-adapters-factory",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "A factory module which provides specific adapter instance based on request data.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -25,7 +25,7 @@
     "@samagra-x/uci-adapters-twilio-sms": "^1.0.0",
     "@samagra-x/uci-adapters-telegram-bot": "^1.0.6",
     "@samagra-x/uci-adapters-pwa": "^1.1.5",
-    "@samagra-x/uci-adapters-fcm": "^1.0.5",
+    "@samagra-x/uci-adapters-fcm": "^1.0.6",
     "jest": "^29.7.0",
     "tsup": "^8.0.0"
   },

--- a/packages/adapters/factory/package.json
+++ b/packages/adapters/factory/package.json
@@ -25,7 +25,7 @@
     "@samagra-x/uci-adapters-twilio-sms": "^1.0.0",
     "@samagra-x/uci-adapters-telegram-bot": "^1.0.6",
     "@samagra-x/uci-adapters-pwa": "^1.1.5",
-    "@samagra-x/uci-adapters-fcm": "^1.0.6",
+    "@samagra-x/uci-adapters-fcm": "^1.0.7",
     "jest": "^29.7.0",
     "tsup": "^8.0.0"
   },

--- a/packages/adapters/fcm/package.json
+++ b/packages/adapters/fcm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samagra-x/uci-adapters-fcm",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A FCM adapter for @samagra-x/uci-adapters-factory",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/adapters/fcm/package.json
+++ b/packages/adapters/fcm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samagra-x/uci-adapters-fcm",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A FCM adapter for @samagra-x/uci-adapters-factory",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/adapters/fcm/src/lib/fcm.provider.ts
+++ b/packages/adapters/fcm/src/lib/fcm.provider.ts
@@ -3,7 +3,7 @@ import admin from 'firebase-admin';
 import { Message } from "firebase-admin/lib/messaging/messaging-api";
 import { FCMProviderConfig } from "./fcm.types";
 import { v4 as uuid4 } from 'uuid';
-import { deleteApp } from "firebase-admin/app";
+import { deleteApp } from "firebase-admin/lib/app/lifecycle";
 
 export class FcmProvider implements XMessageProvider {
 
@@ -70,7 +70,7 @@ export class FcmProvider implements XMessageProvider {
 
         message.data = {
             ...message.data,
-            ...xmsg.payload?.metaData
+            ...xmsg.payload?.metaData?.broadcastData
         }
 
         admin.app(appName).messaging().send(message)

--- a/packages/adapters/fcm/src/lib/fcm.provider.ts
+++ b/packages/adapters/fcm/src/lib/fcm.provider.ts
@@ -3,7 +3,7 @@ import admin from 'firebase-admin';
 import { Message } from "firebase-admin/lib/messaging/messaging-api";
 import { FCMProviderConfig } from "./fcm.types";
 import { v4 as uuid4 } from 'uuid';
-import { deleteApp } from "firebase-admin/lib/app/lifecycle";
+import { deleteApp } from "firebase-admin/app";
 
 export class FcmProvider implements XMessageProvider {
 

--- a/packages/transformers/package.json
+++ b/packages/transformers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samagra-x/uci-transformers",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Library of services, actions and gaurds used to create any custom bot using Xstate configuration.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/transformers/src/modules/generic/broadcast/broadcast.transformer.spec.ts
+++ b/packages/transformers/src/modules/generic/broadcast/broadcast.transformer.spec.ts
@@ -75,7 +75,7 @@ describe('BroadcastTransformer', () => {
                 caption: 'Icon_Image'
             }
         ]);
-        expect(transformedXMessage.payload.metaData).toEqual({
+        expect(transformedXMessage?.payload?.metaData?.broadcastData).toEqual({
             deeplink: mockConfig.deeplink
         });
     });

--- a/packages/transformers/src/modules/generic/broadcast/broadcast.transformer.spec.ts
+++ b/packages/transformers/src/modules/generic/broadcast/broadcast.transformer.spec.ts
@@ -83,11 +83,21 @@ describe('BroadcastTransformer', () => {
         mockConfig.metaData = {
             test: 'test'
         };
+        
         transformer = new BroadcastTransformer(mockConfig);
         const transformedXMessage = await transformer.transform(mockXMessage);
-        expect(transformedXMessage.payload.metaData).toEqual({
+
+        expect(transformedXMessage?.payload?.metaData?.broadcastData).toEqual({
             deeplink: mockConfig.deeplink,
             ...mockConfig.metaData
+        });
+    });
+    it('should transform the xmsg object correctly with without any metaData', async () => {
+        mockConfig.metaData = {};
+        transformer = new BroadcastTransformer(mockConfig);
+        const transformedXMessage = await transformer.transform(mockXMessage);        
+        expect(transformedXMessage?.payload?.metaData?.broadcastData).toEqual({
+            deeplink: mockConfig.deeplink,
         });
     });
 });

--- a/packages/transformers/src/modules/generic/broadcast/broadcast.transformer.ts
+++ b/packages/transformers/src/modules/generic/broadcast/broadcast.transformer.ts
@@ -28,15 +28,21 @@ export class BroadcastTransformer implements ITransformer {
             category: MediaCategory.IMAGE_URL,
             caption: "Icon_Image",
         });
-        xmsg.payload.metaData = {
-            ...xmsg.payload.metaData,
-            deeplink: this.config.deeplink,
-        }
         
+        xmsg.payload.metaData = {
+            broadcastData: {}
+        }
+
+        // Add deeplink inside broadcastData
+        if(this.config?.deeplink){
+            xmsg.payload.metaData.broadcastData.deeplink = this.config.deeplink;
+        }
+
+        // Add metaData inside broadcastData
         if(this.config?.metaData){
-            xmsg.payload.metaData = {
-                ...xmsg.payload.metaData,
-                ...this.config.metaData,
+            xmsg.payload.metaData.broadcastData = {
+                ...xmsg.payload.metaData.broadcastData,
+                ...this.config.metaData
             }
         }
 


### PR DESCRIPTION
Refactor the FCM provider and broadcast transformer to improve code organization and functionality.

- In the FCM provider, import the `deleteApp` function from the correct path in the Firebase Admin library.
- In the broadcast transformer, update the `metaData` object in the `xmsg.payload` to include a `broadcastData` property.
- Add the `deeplink` property to the `broadcastData` object in the broadcast transformer, if it is provided in the configuration.

These changes enhance the FCM provider and broadcast transformer to ensure smooth and efficient messaging functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a structured approach to metadata with the addition of a `broadcastData` object, improving organization and clarity of metadata handling.
- **Bug Fixes**
	- Updated logic for message data processing to focus specifically on `broadcastData`, ensuring more accurate data inclusion.
- **Tests**
	- Adjusted test expectations to reflect the new structure of metadata, ensuring robust validation of the `BroadcastTransformer`.
- **Chores**
	- Incremented package versions for `@samagra-x/uci-adapters-fcm`, `@samagra-x/uci-adapters-factory`, and `@samagra-x/uci-transformers` to reflect updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->