### PR TITLE
revert: set metadata.prompt to be the actual payload array instead of string

### DIFF
--- a/packages/transformers/package.json
+++ b/packages/transformers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samagra-x/uci-transformers",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Library of services, actions and gaurds used to create any custom bot using Xstate configuration.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/transformers/src/modules/generic/llm/llm.transformer.spec.ts
+++ b/packages/transformers/src/modules/generic/llm/llm.transformer.spec.ts
@@ -332,8 +332,8 @@ describe("LLMTransformer Tests", () => {
         const transformedXMsg = await transformer.transform(xmsg);
 
         const expectedPrompt = "You are am assistant who helps with answering questions for users based on the search results. If question is not relevant to search reults/corpus, refuse to answer";
-        expect(transformedXMsg.transformer?.metaData?.prompt).toBe(expectedPrompt);
-        expect(typeof transformedXMsg.transformer?.metaData?.prompt).toBe("string");
+        expect(transformedXMsg.transformer?.metaData?.prompt[0].content).toBe(expectedPrompt);
+        expect(typeof transformedXMsg.transformer?.metaData?.prompt).toBe("object");
 
         
     });
@@ -365,8 +365,8 @@ describe("LLMTransformer Tests", () => {
 
         const transformedXMsg = await transformer.transform(xmsg);
 
-        expect(transformedXMsg.transformer?.metaData?.prompt).toBe(configPrompt);
-        expect(typeof transformedXMsg.transformer?.metaData?.prompt).toBe("string");
+        expect(transformedXMsg.transformer?.metaData?.prompt[0].content).toBe(configPrompt);
+        expect(typeof transformedXMsg.transformer?.metaData?.prompt).toBe("object");
     });
 
     it("should use transformer.metaData.prompt when available and config.prompt is not set", async () => {
@@ -395,8 +395,8 @@ describe("LLMTransformer Tests", () => {
 
         const transformedXMsg = await transformer.transform(xmsg);
 
-        expect(transformedXMsg.transformer?.metaData?.prompt).toBe(metaDataPrompt);
-        expect(typeof transformedXMsg.transformer?.metaData?.prompt).toBe("string");
+        expect(transformedXMsg.transformer?.metaData?.prompt[0].content).toBe(metaDataPrompt);
+        expect(typeof transformedXMsg.transformer?.metaData?.prompt).toBe("object");
     });
 
     it("should replace {{date}} placeholder in the prompt with current date", async () => {
@@ -423,11 +423,10 @@ describe("LLMTransformer Tests", () => {
         });
 
         const transformedXMsg = await transformer.transform(xmsg);
-
-        expect(transformedXMsg.transformer?.metaData?.prompt).toMatch(
+        expect(transformedXMsg.transformer?.metaData?.prompt[0].content).toMatch(
             /Today is [A-Z][a-z]{2} \d{2}, \d{4} \([A-Z][a-z]+\)\. You are a helpful assistant\. Answer the following question:/
         );
-        expect(typeof transformedXMsg.transformer?.metaData?.prompt).toBe("string");
+        expect(typeof transformedXMsg.transformer?.metaData?.prompt).toBe("object");
     });
 });
 

--- a/packages/transformers/src/modules/generic/llm/llm.transformer.ts
+++ b/packages/transformers/src/modules/generic/llm/llm.transformer.ts
@@ -142,7 +142,7 @@ export class LLMTransformer implements ITransformer {
             role: "user",
             content: xmsg?.payload?.text
         })
-        xmsg.transformer.metaData!.prompt = systemInstructions;
+        xmsg.transformer.metaData!.prompt = prompt;
         console.log(`LLM transformer prompt(${xmsg.messageId.Id}): ${JSON.stringify(prompt,null,3)}`);
 
         //llamaIndex implementaion


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `LLMTransformer` to handle prompts as structured objects, enhancing clarity and functionality.
	- Improved response processing logic based on provider type and streaming behavior.

- **Bug Fixes**
	- Enhanced error handling for missing model configurations and ensured correct placeholder replacements in prompts.

- **Version Update**
	- Incremented package version from 1.4.6 to 1.4.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->