### PR TITLE
fix: make wapp timeout 20 minutes

### DIFF
--- a/packages/adapters/factory/package.json
+++ b/packages/adapters/factory/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@fusionauth/typescript-client": "^1.48.0",
     "@samagra-x/xmessage": "^1.1.14",
-    "@samagra-x/uci-adapters-gupshup-whatsapp-adapter": "^2.0.1",
+    "@samagra-x/uci-adapters-gupshup-whatsapp-adapter": "^2.0.2",
     "@samagra-x/uci-adapters-nodemailer": "^1.0.2",
     "@samagra-x/uci-adapters-mailgun": "^1.0.1",
     "@samagra-x/uci-adapters-mailjet": "^1.0.1",

--- a/packages/adapters/gupshup-whatsapp/package.json
+++ b/packages/adapters/gupshup-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samagra-x/uci-adapters-gupshup-whatsapp-adapter",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/adapters/gupshup-whatsapp/src/GupShupWhatsappAdapter.ts
+++ b/packages/adapters/gupshup-whatsapp/src/GupShupWhatsappAdapter.ts
@@ -293,8 +293,8 @@ export class GupshupWhatsappProvider implements XMessageProvider {
   }
 
   private shouldCreateNewConversation(lastMessageTimestamp: number, currentTimestamp: number): boolean {
-    const TEN_MINUTES = 10 * 60 * 1000; // 10 minutes in milliseconds
-    return currentTimestamp - lastMessageTimestamp > TEN_MINUTES;
+    const TWENTY_MINUTES = 20 * 60 * 1000; // 20 minutes in milliseconds
+    return currentTimestamp - lastMessageTimestamp > TWENTY_MINUTES;
   }
 
   updateConversationIdBasedOnUserHistory(xmsg: XMessage, userHistory: any): XMessage {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the time threshold for initiating a new conversation from 10 minutes to 20 minutes in the WhatsApp adapter.

- **Bug Fixes**
	- Adjusted logic for conversation creation timing to enhance user experience.

- **Chores**
	- Updated dependency version for the WhatsApp adapter package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->